### PR TITLE
Update license in package.json to match the rest.

### DIFF
--- a/WebApp/package.json
+++ b/WebApp/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Joppy Furr",
-  "license": "BSD-2-Clause",
+  "license": "MIT",
   "dependencies": {
     "sqlite3": "^4.0.0",
     "express": "^4.17.1",


### PR DESCRIPTION
package.json had a different license string from the rest of the project. this commit fixes that