### PR TITLE
Make the default port for Postgres match Sqlite

### DIFF
--- a/web_app/web_app_postgres.js
+++ b/web_app/web_app_postgres.js
@@ -46,7 +46,7 @@ db.connect ();
  ***************/
 
 let app = express ();
-let port = process.env.PORT || 8003;
+let port = process.env.PORT || 8080;
 
 app.use (compression ())
 


### PR DESCRIPTION
Postgres used port 8003 instead of 8080, this makes it use the same port.